### PR TITLE
Add PT dataset loader with PCA

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -15,3 +15,10 @@ NQUBIT = 4
 C_DEPTH = 4
 # パラメータ最適化の最大イテレーション回数
 MAX_ITER = 100
+
+# Paths to pre-extracted feature datasets
+TRAIN_DATA_PATH = "../data/CIFAR10_test_features.pt"
+TEST_DATA_PATH = "../data/CIFAR10_test_features.pt"
+
+# Dimensionality after PCA compression
+PCA_DIM = 10

--- a/src/train.py
+++ b/src/train.py
@@ -1,11 +1,11 @@
 import numpy as np
-from sklearn import datasets
-from sklearn.model_selection import train_test_split
 from sklearn.metrics import accuracy_score
 
+
 from config import (
-    TEST_SIZE,
-    RANDOM_STATE,
+    TRAIN_DATA_PATH,
+    TEST_DATA_PATH,
+    PCA_DIM,
     SEED,
     NQUBIT,
     C_DEPTH,
@@ -13,21 +13,17 @@ from config import (
 )
 
 from qcl_classification import QclClassification
+from data_utils import load_pt_features
 
 
 def main():
-    # Load iris dataset
-    iris = datasets.load_iris()
-    x = iris.data
-    y = iris.target
-
-    # Split into train and test sets
-    x_train, x_test, y_train_label, y_test_label = train_test_split(
-        x, y, test_size=TEST_SIZE, random_state=RANDOM_STATE, stratify=y
+    # Load features stored in .pt files
+    x_train, x_test, y_train_label, y_test_label = load_pt_features(
+        TRAIN_DATA_PATH, TEST_DATA_PATH, PCA_DIM
     )
 
     # One-hot encode labels
-    num_class = len(np.unique(y))
+    num_class = len(np.unique(y_train_label))
     y_train = np.eye(num_class)[y_train_label]
     y_test = np.eye(num_class)[y_test_label]
 


### PR DESCRIPTION
## Summary
- configure dataset paths for PT files
- add `load_pt_features` helper to handle `.pt` datasets and optional PCA reduction
- update training script to load features via torch and apply PCA

## Testing
- `python -m py_compile src/config.py src/data_utils.py src/train.py`
- ❌ `python -u src/train.py` *(failed due to missing torch dependency)*

------
https://chatgpt.com/codex/tasks/task_b_6879d53cf6188330aec567005155ccb0