### PR TITLE
Enable GPU support for Qulacs

### DIFF
--- a/Dockerfile/Dockerfile
+++ b/Dockerfile/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install required Python packages (except qiskit-aer, we'll build that manually)
 RUN pip install --no-cache-dir \
-    qulacs==0.6.12\
+    qulacs-gpu==0.6.12\
     pytest==8.3.5 \
     matplotlib \
     torchvision==0.16.0 \
@@ -27,4 +27,4 @@ RUN pip install --no-cache-dir \
 COPY . /app
 
 # Default command
-CMD ["python", "src/run.py"]
+CMD ["python", "src/train.py"]

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # Qulacs-LLP
 Qulacsを使ったLLP
 
+GPUアクセラレーションを利用するため、Docker イメージでは `qulacs-gpu`
+をインストールしています。
+
 ## Dockerで
 1. Docker イメージをビルドします。
    ```bash
    docker build -t qulacs-llp -f Dockerfile/Dockerfile .
    ```
+   `qulacs-gpu` が含まれているため、CUDA 対応の環境でビルドしてください。
 2. 作業ディレクトリをコンテナにマウントして学習を実行します。GPU を利用する場合は `--gpus all` を指定します。
    ```bash
    docker run --rm --shm-size=2g --gpus all -v $(pwd):/app -w /app qulacs-llp python -u src/train.py


### PR DESCRIPTION
## Summary
- install `qulacs-gpu` in the Docker image
- run `train.py` by default
- document GPU build and usage

## Testing
- `python -m compileall -q src`
- `python -m py_compile src/train.py`


------
https://chatgpt.com/codex/tasks/task_b_6879d95d078c8330a89cd6f30ef16214