### PR TITLE
Enable GPU Qulacs build

### DIFF
--- a/Dockerfile/Dockerfile
+++ b/Dockerfile/Dockerfile
@@ -39,7 +39,8 @@ RUN git clone --recursive https://github.com/qulacs/qulacs.git && \
     cmake .. -DUSE_GPU=ON -DCMAKE_BUILD_TYPE=Release && \
     make -j && \
     cmake --install . && \
-    export PYTHONPATH=/usr/local/lib/python3.10/site-packages:$PYTHONPATH
+    cd ../python && \
+    pip install .
 
 # 💾 プロジェクトコードをコピー
 COPY . /app

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Qulacs-LLP
 Qulacsを使ったLLP
 
-GPUアクセラレーションを利用するため、Docker イメージでは `qulacs-gpu`
-をインストールしています。
+GPUアクセラレーションを利用するため、Docker イメージでは Qulacs を
+GPU 対応でビルドしています。
 
 ## Dockerで
 1. Docker イメージをビルドします。
    ```bash
    docker build -t qulacs-llp -f Dockerfile/Dockerfile .
    ```
-   `qulacs-gpu` が含まれているため、CUDA 対応の環境でビルドしてください。
+   Qulacs(GPU 対応版) をビルドするため、CUDA が利用できる環境で実行してください。
 2. 作業ディレクトリをコンテナにマウントして学習を実行します。GPU を利用する場合は `--gpus all` を指定します。
    ```bash
    docker run --rm --shm-size=2g --gpus all -v $(pwd):/app -w /app qulacs-llp python -u src/train.py
@@ -19,3 +19,9 @@ Dockerに入るだけ
 ```bash
 docker run --rm --gpus all -v $(pwd):/app -w /app -it qulacs-llp bash
 ```
+
+Qulacs が GPU を認識しているかは次のコマンドで確認できます。
+```bash
+python -c "from qulacs import QuantumStateGpu; print(QuantumStateGpu(1).get_device_name())"
+```
+"cuda" と表示されれば GPU 版が正しくインストールされています。


### PR DESCRIPTION
## Summary
- build Qulacs with CUDA support in Docker image
- show how to verify GPU availability

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6879eb86cbf48330a4c8758b3b5f94a1