### PR TITLE
Implement LLP training with bag-level loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ GPUアクセラレーションを利用するため、Docker イメージでは 
    docker run --rm --shm-size=2g --gpus all -v $(pwd):/app -w /app qulacs-llp python -u src/train.py
    ```
 
+LLP 学習を行う場合は ``train_llp.py`` を実行します。
+```bash
+docker run --rm --gpus all -v $(pwd):/app -w /app qulacs-llp python -u src/train_llp.py
+```
+
 Dockerに入るだけ
 ```bash
 docker run --rm --gpus all -v $(pwd):/app -w /app -it qulacs-llp bash

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ LLP 学習を行う場合は ``train_llp.py`` を実行します。
 docker run --rm --gpus all -v $(pwd):/app -w /app qulacs-llp python -u src/train_llp.py
 ```
 
+`config.py` で `BAG_SIZE` や並列計算用の `N_WORKERS` を調整できます。
+
 Dockerに入るだけ
 ```bash
 docker run --rm --gpus all -v $(pwd):/app -w /app -it qulacs-llp bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -74,3 +74,4 @@ pandas
 qulacs-gpu
 scikit-learn
 matplotlib
+joblib

--- a/src/config.py
+++ b/src/config.py
@@ -15,6 +15,8 @@ NQUBIT = 4
 C_DEPTH = 4
 # パラメータ最適化の最大イテレーション回数
 MAX_ITER = 100
+# LLP bag size
+BAG_SIZE = 100
 
 # Paths to pre-extracted feature datasets
 TRAIN_DATA_PATH = "data/CIFAR10_test_features.pt"

--- a/src/config.py
+++ b/src/config.py
@@ -15,6 +15,8 @@ NQUBIT = 4
 C_DEPTH = 4
 # パラメータ最適化の最大イテレーション回数
 MAX_ITER = 100
+# 並列計算に使用するスレッド数
+N_WORKERS = 1
 # LLP bag size
 BAG_SIZE = 100
 

--- a/src/config.py
+++ b/src/config.py
@@ -10,7 +10,7 @@ RANDOM_STATE = 0
 # 量子回路の初期パラメータ生成に用いる乱数シード
 SEED = 0
 # 使用する量子ビット数
-NQUBIT = 4
+NQUBIT = 10
 # 出力回路の深さ
 C_DEPTH = 4
 # パラメータ最適化の最大イテレーション回数
@@ -21,8 +21,8 @@ N_WORKERS = 1
 BAG_SIZE = 100
 
 # Paths to pre-extracted feature datasets
-TRAIN_DATA_PATH = "data/CIFAR10_test_features.pt"
-TEST_DATA_PATH = "data/CIFAR10_test_features.pt"
+TRAIN_DATA_PATH = "data/CIFAR10_test.pt"
+TEST_DATA_PATH = "data/CIFAR10_test.pt"
 
 # Dimensionality after PCA compression
 PCA_DIM = 4

--- a/src/qcl_classification.py
+++ b/src/qcl_classification.py
@@ -294,7 +294,7 @@ class QclClassification:
             self.theta,
             args=(bag_size, loss),
             method="BFGS",
-            jac=lambda th: self.bag_cost_func_grad(th, bag_size, loss),
+            jac=self.bag_cost_func_grad,
             options={"maxiter": maxiter},
             callback=self.callbackF,
         )

--- a/src/train_llp.py
+++ b/src/train_llp.py
@@ -11,6 +11,7 @@ from config import (
     C_DEPTH,
     MAX_ITER,
     BAG_SIZE,
+    N_WORKERS,
 )
 
 from qcl_classification import QclClassification
@@ -51,7 +52,7 @@ def main():
     teacher_props = np.array(teacher_probs_list)
 
     np.random.seed(SEED)
-    qcl = QclClassification(NQUBIT, C_DEPTH, num_class)
+    qcl = QclClassification(NQUBIT, C_DEPTH, num_class, n_jobs=N_WORKERS)
     _, _, theta_opt = qcl.fit_bags(
         x_bag,
         teacher_props,

--- a/src/train_llp.py
+++ b/src/train_llp.py
@@ -1,0 +1,74 @@
+import numpy as np
+import torch
+from torch.utils.data import TensorDataset
+
+from config import (
+    TRAIN_DATA_PATH,
+    TEST_DATA_PATH,
+    PCA_DIM,
+    SEED,
+    NQUBIT,
+    C_DEPTH,
+    MAX_ITER,
+    BAG_SIZE,
+)
+
+from qcl_classification import QclClassification
+from data_utils import load_pt_features, create_fixed_proportion_batches
+from qulacs import QuantumStateGpu
+
+
+def main():
+    state = QuantumStateGpu(NQUBIT)
+    print(state.get_device_name())
+
+    x_train, x_test, y_train_label, y_test_label = load_pt_features(
+        TRAIN_DATA_PATH, TEST_DATA_PATH, PCA_DIM
+    )
+
+    num_class = len(np.unique(y_train_label))
+
+    train_dataset = TensorDataset(
+        torch.tensor(x_train, dtype=torch.float32),
+        torch.tensor(y_train_label, dtype=torch.long),
+    )
+
+    full_len = len(train_dataset) - len(train_dataset) % BAG_SIZE
+    n_bags = full_len // BAG_SIZE
+
+    teacher_probs_list = []
+    for i in range(n_bags):
+        labels = y_train_label[i * BAG_SIZE : (i + 1) * BAG_SIZE]
+        counts = np.bincount(labels, minlength=num_class).astype(float)
+        teacher_probs_list.append(counts / counts.sum())
+
+    sampler = create_fixed_proportion_batches(
+        train_dataset, teacher_probs_list, BAG_SIZE, num_class
+    )
+
+    ordered_indices = [idx for batch in sampler for idx in batch]
+    x_bag = x_train[ordered_indices]
+    teacher_props = np.array(teacher_probs_list)
+
+    np.random.seed(SEED)
+    qcl = QclClassification(NQUBIT, C_DEPTH, num_class)
+    _, _, theta_opt = qcl.fit_bags(
+        x_bag,
+        teacher_props,
+        BAG_SIZE,
+        maxiter=MAX_ITER,
+        loss="ce",
+    )
+
+    qcl.set_input_state(x_train[:full_len])
+    bag_pred_train = qcl.bag_pred(theta_opt, BAG_SIZE)
+
+    qcl.set_input_state(x_test[: len(x_test) - len(x_test) % BAG_SIZE])
+    bag_pred_test = qcl.bag_pred(theta_opt, BAG_SIZE)
+
+    print("train bag preds shape:", bag_pred_train.shape)
+    print("test bag preds shape:", bag_pred_test.shape)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `BAG_SIZE` to config
- support bag-based prediction and loss in `QclClassification`
- implement a new training script `train_llp.py`
- document how to run LLP training

## Testing
- `python -m py_compile src/qcl_classification.py src/train_llp.py src/config.py`

------
https://chatgpt.com/codex/tasks/task_b_68806eb38ee08330b31b9ec538bc98fd