### PR TITLE
Add LLP training utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ GPUアクセラレーションを利用するため、Docker イメージでは 
    `qulacs-gpu` が含まれているため、CUDA 対応の環境でビルドしてください。
 2. 作業ディレクトリをコンテナにマウントして学習を実行します。GPU を利用する場合は `--gpus all` を指定します。
    ```bash
-   docker run --rm --shm-size=8g --gpus all -v $(pwd):/app -w /app qulacs-llp python -u src/train.py
+   docker run --rm --shm-size=8g --gpus all -v $(pwd):/app -w /app qulacs-llp python -u src/train_llp.py
    ```
 
 Dockerに入るだけ

--- a/src/config.py
+++ b/src/config.py
@@ -16,6 +16,9 @@ C_DEPTH = 4
 # パラメータ最適化の最大イテレーション回数
 MAX_ITER = 100
 
+# Number of instances per bag for LLP
+BAG_SIZE = 100
+
 # Paths to pre-extracted feature datasets
 TRAIN_DATA_PATH = "data/CIFAR10_test_features.pt"
 TEST_DATA_PATH = "data/CIFAR10_test_features.pt"

--- a/src/qcl_classification.py
+++ b/src/qcl_classification.py
@@ -5,6 +5,7 @@ from scipy.optimize import minimize
 from qcl_utils import create_time_evol_gate, min_max_scaling, softmax
 
 from tqdm import tqdm
+from joblib import Parallel, delayed
 
 
 class QclClassification:
@@ -92,25 +93,54 @@ class QclClassification:
         theta = [self.output_gate.get_parameter(ind) for ind in range(parameter_count)]
         return np.array(theta)
 
-    def pred(self, theta):
-        """x_listに対して、モデルの出力を計算"""
+    def _pred_instances(self, theta, indices=None, show_progress=True):
+        """Return predictions for specified instance indices."""
 
-        # 入力状態準備
-        # st_list = self.input_state_list
-        st_list = [st.copy() for st in self.input_state_list]  # ここで各要素ごとにcopy()しないとディープコピーにならない
-        # U_outの更新
+        if indices is None:
+            indices = range(len(self.input_state_list))
+        st_list = [self.input_state_list[i].copy() for i in indices]
+
         self.update_output_gate(theta)
 
         res = []
-        # 出力状態計算 & 観測
-        for st in tqdm(st_list, desc="pred instance"):
-            # U_outで状態を更新
+        iterator = st_list
+        if show_progress:
+            iterator = tqdm(st_list, desc="pred instance")
+        for st in iterator:
             self.output_gate.update_quantum_state(st)
-            # モデルの出力
-            r = [o.get_expectation_value(st) for o in self.obs]  # 出力多次元ver
+            r = [o.get_expectation_value(st) for o in self.obs]
             r = softmax(r)
             res.append(r.tolist())
         return np.array(res)
+
+    def pred(self, theta):
+        """Compute predictions for all stored input states."""
+        return self._pred_instances(theta)
+
+    def pred_bags(self, theta, bags, n_jobs=None):
+        """Predict class proportions for a list of bags.
+
+        Parameters
+        ----------
+        theta : array-like
+            Circuit parameters.
+        bags : Sequence[Sequence[int]]
+            Each element is a list of instance indices forming a bag.
+        n_jobs : int, optional
+            Number of parallel jobs when aggregating predictions.
+        """
+
+        inst_pred = self._pred_instances(theta, show_progress=False)
+
+        def bag_mean(idxs):
+            return inst_pred[list(idxs)].mean(axis=0)
+
+        if n_jobs is None or n_jobs == 1:
+            bag_res = [bag_mean(b) for b in bags]
+        else:
+            bag_res = Parallel(n_jobs=n_jobs)(delayed(bag_mean)(b) for b in bags)
+
+        return np.array(bag_res)
 
     def cost_func(self, theta):
         """コスト関数を計算するクラス
@@ -138,6 +168,36 @@ class QclClassification:
     def cost_func_grad(self, theta):
         y_minus_t = self.pred(theta) - self.y_list
         B_gr_list = self.B_grad(theta)
+        grad = [np.sum(y_minus_t * B_gr) for B_gr in B_gr_list]
+        return np.array(grad)
+
+    # === LLP utilities ===
+    def bag_cost_func(self, theta):
+        """Compute bag-level loss."""
+        pred_bags = self.pred_bags(theta, self.bags, n_jobs=self.n_jobs)
+        eps = 1e-12
+        if self.loss_type == "kl":
+            loss = np.sum(
+                self.teacher_bags * (np.log(self.teacher_bags + eps) - np.log(pred_bags + eps))
+            ) / len(self.bags)
+        else:  # cross-entropy
+            loss = -np.sum(self.teacher_bags * np.log(pred_bags + eps)) / len(self.bags)
+        return loss
+
+    def B_grad_bag(self, theta):
+        theta_plus = [theta.copy() + np.eye(len(theta))[i] * np.pi / 2. for i in range(len(theta))]
+        theta_minus = [theta.copy() - np.eye(len(theta))[i] * np.pi / 2. for i in range(len(theta))]
+
+        grad = [
+            (self.pred_bags(theta_plus[i], self.bags, n_jobs=self.n_jobs) -
+             self.pred_bags(theta_minus[i], self.bags, n_jobs=self.n_jobs)) / 2.
+            for i in range(len(theta))
+        ]
+        return np.array(grad)
+
+    def bag_cost_func_grad(self, theta):
+        y_minus_t = self.pred_bags(theta, self.bags, n_jobs=self.n_jobs) - self.teacher_bags
+        B_gr_list = self.B_grad_bag(theta)
         grad = [np.sum(y_minus_t * B_gr) for B_gr in B_gr_list]
         return np.array(grad)
 
@@ -198,10 +258,77 @@ class QclClassification:
         print()
         return result, theta_init, theta_opt
 
+    def fit_bags(self, x_list, bags, teacher_props, maxiter=1000, loss_type="cross_entropy", n_jobs=None):
+        """Fit the model using bag-level label proportions.
+
+        Parameters
+        ----------
+        x_list : array-like
+            Feature vectors for all instances.
+        bags : Sequence[Sequence[int]]
+            Indices defining each bag.
+        teacher_props : array-like
+            True label proportions for each bag.
+        maxiter : int
+            Maximum iterations for ``scipy.optimize.minimize``.
+        loss_type : {"cross_entropy", "kl"}
+            Loss function to use.
+        n_jobs : int, optional
+            Parallel jobs for bag prediction aggregation.
+        """
+
+        if self.num_class is None:
+            self.num_class = teacher_props.shape[1]
+            self._initialize_observable()
+        elif self.obs is None:
+            self._initialize_observable()
+
+        self.set_input_state(x_list)
+        self.create_initial_output_gate()
+        theta_init = self.theta
+
+        self.bags = [list(b) for b in bags]
+        self.teacher_bags = np.array(teacher_props)
+        self.loss_type = "kl" if loss_type.lower() == "kl" else "cross_entropy"
+        self.n_jobs = n_jobs
+
+        self.n_iter = 0
+        self.maxiter = maxiter
+
+        print("Initial parameter:")
+        print(self.theta)
+        print()
+        print(f"Initial value of cost function:  {self.bag_cost_func(self.theta):.4f}")
+        print()
+        print('============================================================')
+        print("Iteration count...")
+        result = minimize(
+            self.bag_cost_func,
+            self.theta,
+            method="BFGS",
+            jac=self.bag_cost_func_grad,
+            options={"maxiter": maxiter},
+            callback=self.callbackF,
+        )
+
+        theta_opt = self.theta
+        print('============================================================')
+        print()
+        print("Optimized parameter:")
+        print(self.theta)
+        print()
+        print(f"Final value of cost function:  {self.bag_cost_func(self.theta):.4f}")
+        print()
+        return result, theta_init, theta_opt
+
     def callbackF(self, theta):
             self.n_iter = self.n_iter + 1
             if 10 * self.n_iter % self.maxiter == 0:
-                print(f"Iteration: {self.n_iter} / {self.maxiter},   Value of cost_func: {self.cost_func(theta):.4f}")
+                if hasattr(self, "bags"):
+                    val = self.bag_cost_func(theta)
+                else:
+                    val = self.cost_func(theta)
+                print(f"Iteration: {self.n_iter} / {self.maxiter},   Value of cost_func: {val:.4f}")
 
 
 def main():

--- a/src/train_llp.py
+++ b/src/train_llp.py
@@ -1,0 +1,56 @@
+import numpy as np
+import torch
+from torch.utils.data import TensorDataset
+
+from config import (
+    TRAIN_DATA_PATH,
+    TEST_DATA_PATH,
+    PCA_DIM,
+    SEED,
+    NQUBIT,
+    C_DEPTH,
+    MAX_ITER,
+    BAG_SIZE,
+)
+
+from qcl_classification import QclClassification
+from data_utils import load_pt_features, create_fixed_proportion_batches
+from qulacs import QuantumStateGpu
+
+
+def main():
+    state = QuantumStateGpu(NQUBIT)
+    print(state.get_device_name())
+
+    x_train, _, y_train_label, _ = load_pt_features(
+        TRAIN_DATA_PATH, TEST_DATA_PATH, PCA_DIM
+    )
+
+    num_class = len(np.unique(y_train_label))
+
+    np.random.seed(SEED)
+
+    train_dataset = TensorDataset(
+        torch.tensor(x_train, dtype=torch.float32),
+        torch.tensor(y_train_label, dtype=torch.long),
+    )
+
+    num_bags = len(train_dataset) // BAG_SIZE
+    teacher_probs = np.random.dirichlet(np.ones(num_class), size=num_bags)
+    sampler = create_fixed_proportion_batches(
+        train_dataset, teacher_probs.tolist(), BAG_SIZE, num_class
+    )
+    bags = sampler.batches
+
+    qcl = QclClassification(NQUBIT, C_DEPTH, num_class)
+    _, _, theta_opt = qcl.fit_bags(
+        x_train, bags, teacher_probs, maxiter=MAX_ITER, loss_type="cross_entropy"
+    )
+
+    preds = qcl.pred_bags(theta_opt, bags)
+    print("First bag predicted proportions:", preds[0])
+    print("First bag teacher proportions:", teacher_probs[0])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- extend configuration with `BAG_SIZE`
- implement bag-level loss and training in `QclClassification`
- add script `train_llp.py` demonstrating LLP with fixed-proportion bags

## Testing
- `python -m py_compile src/*.py`
- `pip install numpy torch joblib`
- `python src/train_llp.py` *(fails: ModuleNotFoundError: No module named 'qulacs')*

------
https://chatgpt.com/codex/tasks/task_b_68808a70786483309e0cfefe4fc64a75