### PR TITLE
Add GPU toggle configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Qulacsを使ったLLP
 GPUアクセラレーションを利用するため、Docker イメージでは `qulacs-gpu`
 をインストールしています。
 
+`src/config.py` の `USE_GPU` を `True` にすると、量子状態の計算で GPU 実装
+を使用します。CPU で実行する場合は `False` にしてください。
+
 ## Dockerで
 1. Docker イメージをビルドします。
    ```bash

--- a/src/config.py
+++ b/src/config.py
@@ -22,3 +22,6 @@ TEST_DATA_PATH = "data/CIFAR10_test_features.pt"
 
 # Dimensionality after PCA compression
 PCA_DIM = 4
+
+# Whether to use GPU acceleration with qulacs
+USE_GPU = False

--- a/src/qcl_classification.py
+++ b/src/qcl_classification.py
@@ -1,5 +1,10 @@
 import numpy as np
+from config import USE_GPU
 from qulacs import QuantumState, Observable, QuantumCircuit, ParametricQuantumCircuit
+try:
+    from qulacs import QuantumStateGpu
+except ImportError:  # CPU-only installation
+    QuantumStateGpu = QuantumState
 from sklearn.metrics import log_loss
 from scipy.optimize import minimize
 from qcl_utils import create_time_evol_gate, min_max_scaling, softmax
@@ -58,8 +63,10 @@ class QclClassification:
         
         st_list = []
         
+        state_cls = QuantumStateGpu if USE_GPU else QuantumState
+
         for x in x_list_normalized:
-            st = QuantumState(self.nqubit)
+            st = state_cls(self.nqubit)
             input_gate = self.create_input_gate(x)
             input_gate.update_quantum_state(st)
             st_list.append(st.copy())

--- a/src/train.py
+++ b/src/train.py
@@ -13,10 +13,11 @@ from config import (
 
 from qcl_classification import QclClassification
 from data_utils import load_pt_features
-from qulacs import QuantumStateGpu
+from qulacs import QuantumState, QuantumStateGpu
+from config import USE_GPU
 
 def main():
-    state = QuantumStateGpu(NQUBIT)  # ← GPU版ではこれも自動で GPU 実装に切り替わる
+    state = QuantumStateGpu(NQUBIT) if USE_GPU else QuantumState(NQUBIT)
     print(state.get_device_name())
 
     # Load features stored in .pt files


### PR DESCRIPTION
## Summary
- allow choosing QuantumState or QuantumStateGpu depending on new `USE_GPU` flag
- document GPU option in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python src/train.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_b_68809c4293288330962ea945a9998429