### PR TITLE
Add backpropagation training method

### DIFF
--- a/src/train_backprop.py
+++ b/src/train_backprop.py
@@ -1,0 +1,47 @@
+import numpy as np
+from sklearn.metrics import accuracy_score
+
+from config import (
+    TRAIN_DATA_PATH,
+    TEST_DATA_PATH,
+    PCA_DIM,
+    SEED,
+    NQUBIT,
+    C_DEPTH,
+    MAX_ITER,
+)
+
+from qcl_classification import QclClassification
+from data_utils import load_pt_features
+from qulacs import QuantumState, QuantumStateGpu
+from config import USE_GPU
+
+
+def main():
+    state = QuantumStateGpu(NQUBIT) if USE_GPU else QuantumState(NQUBIT)
+    print(state.get_device_name())
+
+    # Load pre-extracted features
+    x_train, x_test, y_train_label, y_test_label = load_pt_features(
+        TRAIN_DATA_PATH, TEST_DATA_PATH, PCA_DIM
+    )
+
+    num_class = len(np.unique(y_train_label))
+
+    np.random.seed(SEED)
+
+    qcl = QclClassification(NQUBIT, C_DEPTH, num_class)
+    qcl.fit_backprop_inner_product(x_train, y_train_label, n_iter=MAX_ITER, lr=0.1)
+
+    pred_train = qcl.pred_amplitude(x_train)
+    acc_train = accuracy_score(y_train_label, np.argmax(pred_train, axis=1))
+
+    pred_test = qcl.pred_amplitude(x_test)
+    acc_test = accuracy_score(y_test_label, np.argmax(pred_test, axis=1))
+
+    print(f"train accuracy: {acc_train:.3f}")
+    print(f"test accuracy: {acc_test:.3f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement training via `backprop_inner_product`
- expose `pred_amplitude` and `fit_backprop_inner_product` in classifier
- add example training script using new method

## Testing
- `python -m py_compile src/qcl_classification.py src/train_backprop.py`
- `PYTHONPATH=src python - <<'PY'
import numpy as np
from qcl_classification import QclClassification
nqubit=2; c_depth=1
x=np.random.rand(5,2); y=np.random.randint(0,2,5)
q=QclClassification(nqubit,c_depth,2)
q.fit_backprop_inner_product(x,y,n_iter=5,lr=0.05)
print(q.pred_amplitude(x))
PY`

------
https://chatgpt.com/codex/tasks/task_b_6886e30e26e483309a2e73ff3de82dd4