### PR TITLE
Enable GPU install in Dockerfile

### DIFF
--- a/Dockerfile/Dockerfile
+++ b/Dockerfile/Dockerfile
@@ -26,7 +26,7 @@ RUN git clone --recursive https://github.com/qulacs/qulacs.git /app/qulacs && \
     make -j
 
 # Python バインディングを pip 経由でインストール（qulacs_core.so が含まれる）
-RUN pip install /app/qulacs
+RUN USE_GPU=ON pip install /app/qulacs
 
 COPY . /app
 


### PR DESCRIPTION
## Summary
- pass USE_GPU=ON to pip when installing Qulacs

## Testing
- `pytest -q`
- `podman build -t qulacs-llp -f Dockerfile/Dockerfile .` *(fails: cannot complete image pull)*

------
https://chatgpt.com/codex/tasks/task_b_68870d1295508330a1f48bb0efb3cf0a